### PR TITLE
optimize window drag

### DIFF
--- a/Scripts/TopArea.gd
+++ b/Scripts/TopArea.gd
@@ -11,74 +11,64 @@ var maximized : bool = false
 var minimized_size : Vector2
 var minimized_pos : Vector2
 
-func _ready() -> void:
-	Defaults.connect("view_changed", self, "on_view_changed")
-	Defaults.connect("update_view_info", self, "on_update_view_info")
+var offset : Vector2 
 
-	set_process_input(false)
-	var res = load(Defaults.TIMETRACKS_SAVE_PATH + Defaults.TIMETRACKS_SAVE_NAME)	# TODO: access this resource 
-	
+func _ready() -> void:
+    # ....
+    connect("mouse_entered", self, "_on_mouse_entered")
+    connect("mouse_exited", self, "_on_mouse_exited")
+    # ... should be moved to a _connect_signals() function?
+    
+    Defaults.connect("view_changed", self, "on_view_changed")
+    Defaults.connect("update_view_info", self, "on_update_view_info")
+
+    var res = load(Defaults.TIMETRACKS_SAVE_PATH + Defaults.TIMETRACKS_SAVE_NAME)	# TODO: access this resource 
+        
+func _on_mouse_entered() -> void:
+    set_process_input(true)
+
+func _on_mouse_exited() -> void:
+    set_process_input(false)
 
 func _input(event: InputEvent) -> void:
-	if event is InputEventMouseMotion:
-		drag_amount += event.relative
-	OS.window_position.x = clamp(drag_amount.x - orig_position.x, 0, OS.get_screen_size().x - OS.window_size.x)
-	OS.window_position.y = clamp(drag_amount.y - orig_position.y, 0, OS.get_screen_size().y - OS.window_size.y)
-
-
-func _on_TopArea_gui_input(event: InputEvent) -> void:
-	if event is InputEventMouseButton:
-		if event.pressed:
-			dragging = true
-
-			if OS.window_maximized:
-				OS.window_maximized = false
-				OS.window_size = Vector2(1100, 700)
-				OS.window_position.y = 0
-				$Right/Maximize.pressed = false
-
-#			mouse_drag_beg = get_viewport().get_mouse_position()
-			orig_position = get_viewport().get_mouse_position() - OS.window_position
-			drag_amount = get_viewport().get_mouse_position()
-#			print(get_global_mouse_position())
-#			initial_mouse_pos = get_local_mouse_position()
-			initial_mouse_pos = get_global_mouse_position()
-			Input.set_mouse_mode(2)
-
-
-			set_process_input(true)
-		else:
-			dragging = false
-			set_process_input(false)
-			Input.set_mouse_mode(0)
-			Input.warp_mouse_position(initial_mouse_pos)
+    if event is InputEventMouseButton:
+        if event.pressed:
+            offset = get_global_mouse_position()
+        else:
+            offset = Vector2()
+    if event is InputEventMouseMotion and offset != Vector2():
+        if OS.get_window_size() > Defaults.settings_res.minimized_window_size or OS.window_maximized:
+            OS.window_maximized = false
+            OS.window_size = Defaults.settings_res.window_size
+            $Right/Maximize.pressed = false
+        OS.set_window_position(OS.get_window_position() + event.get_global_position() - offset)
 
 
 func _on_Minimuze_pressed() -> void:
-	OS.window_minimized = true
+    OS.window_minimized = true
 
 
 func _on_Exit_pressed() -> void:
-	Defaults.quit()
+    Defaults.quit()
 
 
 func _on_Maximize_toggled(button_pressed: bool) -> void:
-	if button_pressed:
-		Defaults.settings_res.minimized_window_size = OS.window_size
-		Defaults.settings_res.minimized_window_position = OS.window_position
-		Defaults.settings_res.window_maximized = true
-		Defaults.save_settings_resource()
-		OS.window_maximized = button_pressed
-	else:
-		OS.window_maximized = false
-		Defaults.settings_res.window_maximized = false
-		OS.window_size = Defaults.settings_res.minimized_window_size
-		OS.window_position = Defaults.settings_res.minimized_window_position
-		Defaults.save_settings_resource()
-		
+    if button_pressed:
+        Defaults.settings_res.minimized_window_size = OS.window_size
+        Defaults.settings_res.minimized_window_position = OS.window_position
+        Defaults.settings_res.window_maximized = true
+        Defaults.save_settings_resource()
+        OS.window_maximized = button_pressed
+    else:
+        OS.window_maximized = false
+        Defaults.settings_res.window_maximized = false
+        OS.window_size = Defaults.settings_res.minimized_window_size
+        OS.window_position = Defaults.settings_res.minimized_window_position
+        Defaults.save_settings_resource()
+                
 
 func change_window_title(_name : String) -> void:
-	$Left/ViewLabel.text = _name
+    $Left/ViewLabel.text = _name
 #	$Tween.stop_all()
 #	$Tween.interpolate_property($Right/ViewLabel, "percent_visible", $Right/ViewLabel.percent_visible, 0.0, 0.5, Tween.TRANS_LINEAR, Tween.EASE_OUT, 0.0)
 #	$Tween.interpolate_property($Right/ViewLabel, "percent_visible", 0.0, 1.0, 0.5, Tween.TRANS_LINEAR, Tween.EASE_OUT, 0.5)
@@ -89,36 +79,36 @@ func change_window_title(_name : String) -> void:
 
 # IMPORTANT: This func sets up the top area according to how to the new view
 func on_view_changed(_name : String, _button : bool, _input_field : bool) -> void:
-	change_window_title(_name)
-	if _name == "Time tracking":
-		$Left/NewBtn.hide()
-		$Left/LineEdit.hide()
-	else:
-		$Left/LineEdit.visible = _input_field
-		$Left/NewBtn.visible = _button
+    change_window_title(_name)
+    if _name == "Time tracking":
+        $Left/NewBtn.hide()
+        $Left/LineEdit.hide()
+    else:
+        $Left/LineEdit.visible = _input_field
+        $Left/NewBtn.visible = _button
 
 
 func _on_Button_pressed() -> void:
-	if Defaults.active_view_pointer and Defaults.active_view_pointer.has_method("on_new_top_bar_button"):
-		var message : Dictionary = {}
-		if $Left/LineEdit.text != "":
-			message.text = $Left/LineEdit.text
-			$Left/LineEdit.clear()
-		Defaults.active_view_pointer.on_new_top_bar_button(message)
+    if Defaults.active_view_pointer and Defaults.active_view_pointer.has_method("on_new_top_bar_button"):
+        var message : Dictionary = {}
+        if $Left/LineEdit.text != "":
+            message.text = $Left/LineEdit.text
+            $Left/LineEdit.clear()
+        Defaults.active_view_pointer.on_new_top_bar_button(message)
 
 
 func _on_Shortcuts_shortcut_use() -> void:
-	_on_Button_pressed()
+    _on_Button_pressed()
 
 
 func _on_Shortcuts_shortcut_focus() -> void:
-	if $Left/LineEdit.visible:
-		$Left/LineEdit.grab_focus()
+    if $Left/LineEdit.visible:
+        $Left/LineEdit.grab_focus()
 
 
 func on_update_view_info(text : String) -> void:
-	if text:
-		$Right/ViewInfoPanel.show()
-		$Right/ViewInfoPanel/ViewInfoLabel.text = text
-	else:
-		$Right/ViewInfoPanel.hide()
+    if text:
+        $Right/ViewInfoPanel.show()
+        $Right/ViewInfoPanel/ViewInfoLabel.text = text
+    else:
+        $Right/ViewInfoPanel.hide()

--- a/Scripts/TopArea.gd
+++ b/Scripts/TopArea.gd
@@ -13,16 +13,7 @@ var minimized_pos : Vector2
 
 var offset : Vector2 
 
-onready var screen_size: Vector2 = OS.get_screen_size()
-
-var min_screen_pos: Vector2
-var max_screen_size: Vector2
-
 func _ready() -> void:
-    for i in range(0, OS.get_screen_count()):
-        min_screen_pos.x = min(min_screen_pos.x, OS.get_screen_position(i).x)
-        max_screen_size.x = max(max_screen_size.x, (OS.get_screen_position(i)+OS.get_screen_size(i)).x)
-        max_screen_size.y = max(max_screen_size.y, (OS.get_screen_position(i)+OS.get_screen_size(i)).y)
     # ....
     connect("mouse_entered", self, "_on_mouse_entered")
     connect("mouse_exited", self, "_on_mouse_exited")
@@ -50,12 +41,7 @@ func _input(event: InputEvent) -> void:
         if OS.window_maximized:
             offset *=  Defaults.settings_res.minimized_window_size.x / OS.get_window_size().x
             $Right/Maximize.pressed = false
-        drag_amount = OS.get_window_position() + event.get_global_position() - offset
-        OS.set_window_position(
-            Vector2(
-                clamp(drag_amount.x, min_screen_pos.x, max_screen_size.x - OS.get_window_size().x),
-                clamp(drag_amount.y, min_screen_pos.y, max_screen_size.y - OS.get_window_size().y)
-                ))
+        OS.set_window_position(OS.get_window_position() + event.get_global_position() - offset)
 
 
 func _on_Minimuze_pressed() -> void:

--- a/Scripts/TopArea.gd
+++ b/Scripts/TopArea.gd
@@ -13,7 +13,16 @@ var minimized_pos : Vector2
 
 var offset : Vector2 
 
+onready var screen_size: Vector2 = OS.get_screen_size()
+
+var min_screen_pos: Vector2
+var max_screen_size: Vector2
+
 func _ready() -> void:
+    for i in range(0, OS.get_screen_count()):
+        min_screen_pos.x = min(min_screen_pos.x, OS.get_screen_position(i).x)
+        max_screen_size.x = max(max_screen_size.x, (OS.get_screen_position(i)+OS.get_screen_size(i)).x)
+        max_screen_size.y = max(max_screen_size.y, (OS.get_screen_position(i)+OS.get_screen_size(i)).y)
     # ....
     connect("mouse_entered", self, "_on_mouse_entered")
     connect("mouse_exited", self, "_on_mouse_exited")
@@ -41,7 +50,12 @@ func _input(event: InputEvent) -> void:
         if OS.window_maximized:
             offset *=  Defaults.settings_res.minimized_window_size.x / OS.get_window_size().x
             $Right/Maximize.pressed = false
-        OS.set_window_position(OS.get_window_position() + event.get_global_position() - offset)
+        drag_amount = OS.get_window_position() + event.get_global_position() - offset
+        OS.set_window_position(
+            Vector2(
+                clamp(drag_amount.x, min_screen_pos.x, max_screen_size.x - OS.get_window_size().x),
+                clamp(drag_amount.y, min_screen_pos.y, max_screen_size.y - OS.get_window_size().y)
+                ))
 
 
 func _on_Minimuze_pressed() -> void:

--- a/Scripts/TopArea.gd
+++ b/Scripts/TopArea.gd
@@ -32,14 +32,14 @@ func _on_mouse_exited() -> void:
 
 func _input(event: InputEvent) -> void:
     if event is InputEventMouseButton:
+        initial_mouse_pos = get_global_mouse_position()
         if event.pressed:
             offset = get_global_mouse_position()
         else:
             offset = Vector2()
     if event is InputEventMouseMotion and offset != Vector2():
-        if OS.get_window_size() > Defaults.settings_res.minimized_window_size or OS.window_maximized:
-            OS.window_maximized = false
-            OS.window_size = Defaults.settings_res.window_size
+        if OS.window_maximized:
+            offset *=  Defaults.settings_res.minimized_window_size.x / OS.get_window_size().x
             $Right/Maximize.pressed = false
         OS.set_window_position(OS.get_window_position() + event.get_global_position() - offset)
 


### PR DESCRIPTION
Hi all! I've just bought Mad Productivity on itch.io, and I really like this so far.
I've noticed that dragging the window is extremely slow and on Windows the lag is pretty bad.
Here's a quick fix to make it smooth. Handling `OS` operations directly to the window is pretty resource-intensive in Godot as I've already experienced with some UI customization projects.
[Here's how I'm handling it in one app of mine](https://github.com/GodotNuts/FirebaseDemo-SociaDot/blob/main/main/scn/app/top_bar.gd), thanks to the team I've achieved a smooth lag-less dragging on most of desktop OS (windows, ubuntu and macOS), and I think that this implementation would be really useful for Mad Productivity UX.
I've also tried to fixed the resizing on dragging while the window is maximized, to keep the aspect ratio between the mouse position and the window's one.

Before (*release* mode, in *debug* mode the lag is even worse)
https://user-images.githubusercontent.com/45271396/141540473-3744d490-d46c-4c83-ac69-2c28c2d724b1.mp4

After (debug mode and recording the screen drops some frames, in release mode performance should be improved!)
https://user-images.githubusercontent.com/45271396/141540503-7e7cc41a-9f12-47ed-ab60-372b754cc738.mp4

Hope you find it useful.
Cheers!