### PR TITLE
"No Data" Text on Time Tracking View

### DIFF
--- a/Assets/Views/TimeTracking.tscn
+++ b/Assets/Views/TimeTracking.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=9 format=2]
+[gd_scene load_steps=10 format=2]
 
 [ext_resource path="res://Assets/Textures/SimpleGradient.png" type="Texture" id=1]
 [ext_resource path="res://Scripts/CustomTransparentButton.gd" type="Script" id=2]
 [ext_resource path="res://Assets/Buttons/X_normal.png" type="Texture" id=3]
 [ext_resource path="res://Assets/Themes/Roboto12Clean.tres" type="Theme" id=4]
+[ext_resource path="res://Assets/Fonts/Roboto40.tres" type="DynamicFont" id=5]
 [ext_resource path="res://Scripts/Views/TimeTracking.gd" type="Script" id=11]
 [ext_resource path="res://Scripts/Views/TimeTracking/TrackedItem.gd" type="Script" id=12]
 [ext_resource path="res://Assets/Buttons/TimeTrackBtnWhite.png" type="Texture" id=16]
@@ -14,6 +15,24 @@ margin_right = 990.0
 margin_bottom = 571.0
 rect_clip_content = true
 script = ExtResource( 11 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="NoDataText" type="Label" parent="."]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -485.5
+margin_top = -70.5
+margin_right = 485.5
+margin_bottom = 70.5
+custom_colors/font_color = Color( 0.854902, 0.423529, 0.384314, 1 )
+custom_fonts/font = ExtResource( 5 )
+text = "NO DATA, YET!"
+align = 1
+valign = 1
 __meta__ = {
 "_edit_use_anchors_": false
 }

--- a/Scripts/Views/TimeTracking.gd
+++ b/Scripts/Views/TimeTracking.gd
@@ -16,7 +16,6 @@ func _ready() -> void:
 		load_res()
 	load_time_tracks()
 	update_total_time()
-	check_tracks_count()
 
 
 func load_res() -> void:
@@ -85,7 +84,7 @@ func save() -> void:
 
 
 func update_total_time() -> void:
-	pass
+	check_tracks_count()
 #	var _time : Array = get_hours_minutes_seconds(total_secs)
 #	$CommandPanel/Total.text = "total " + _time[2] + ":" + _time[1] + ":" + _time[0]
 
@@ -94,7 +93,6 @@ func remove_time_track(idx : int) -> void:
 	#total_secs -= res.tracks[idx].length
 	res.tracks.erase(idx)
 	update_total_time()
-	check_tracks_count()
 
 
 func update_time_track_item_text(_text : String, _id : int) -> void:

--- a/Scripts/Views/TimeTracking.gd
+++ b/Scripts/Views/TimeTracking.gd
@@ -16,6 +16,7 @@ func _ready() -> void:
 		load_res()
 	load_time_tracks()
 	update_total_time()
+	check_tracks_count()
 
 
 func load_res() -> void:
@@ -93,6 +94,7 @@ func remove_time_track(idx : int) -> void:
 	#total_secs -= res.tracks[idx].length
 	res.tracks.erase(idx)
 	update_total_time()
+	check_tracks_count()
 
 
 func update_time_track_item_text(_text : String, _id : int) -> void:
@@ -138,3 +140,7 @@ func _on_TimeTrackingPanel_register_time_track_item(item : TimeTrackItem) -> voi
 	var id : int = res.add_finished_track(item)
 	create_track_visual(item.name, item.get_start_unix_time(), item.get_duration(), id)
 	update_view_text()
+	check_tracks_count()
+
+func check_tracks_count() -> void:
+	$NoDataText.visible = res.tracks.size() == 0

--- a/Scripts/Views/TimeTracking.gd
+++ b/Scripts/Views/TimeTracking.gd
@@ -103,6 +103,7 @@ func update_time_track_item_text(_text : String, _id : int) -> void:
 
 func update_theme() -> void:
 	$Gradient.modulate = Defaults.ui_theme.darker
+	$NoDataText.add_color_override("font_color", Defaults.ui_theme.highlight_colour)
 	
 	
 func update_view_text() -> void:


### PR DESCRIPTION
# CHANGES
- Added "no data" text on the Time Tracking view so the page doesn't appear so empty when there are no time entries. 
# SCREENSHOT
![image](https://user-images.githubusercontent.com/10349078/141810790-0b4a694c-f510-4898-999c-3b3bebbd7620.png)
