### PR TITLE
Fixed Issue #30

### DIFF
--- a/Main.tscn
+++ b/Main.tscn
@@ -71,9 +71,6 @@ bg_color = Color( 0.0862745, 0.152941, 0.160784, 1 )
 anchor_right = 1.0
 anchor_bottom = 1.0
 script = ExtResource( 15 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="MainWorkspace" type="Panel" parent="."]
 anchor_right = 1.0
@@ -87,9 +84,6 @@ __meta__ = {
 anchor_right = 1.0
 anchor_bottom = 1.0
 custom_constants/separation = 0
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="Sidebar" type="Panel" parent="MainWorkspace/HBX" groups=["UI_THEME"]]
 margin_right = 50.0
@@ -105,9 +99,6 @@ __meta__ = {
 anchor_right = 1.0
 anchor_bottom = 1.0
 alignment = 1
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="TimeTrackPanel" type="TextureButton" parent="MainWorkspace/HBX/Sidebar/Buttons"]
 margin_left = 13.0

--- a/Main.tscn
+++ b/Main.tscn
@@ -325,9 +325,6 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 custom_constants/separation = 0
 alignment = 1
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="Control" type="Control" parent="MainWorkspace/HBX/VBX/TopArea/Left"]
 margin_right = 14.0

--- a/Scripts/TopArea.gd
+++ b/Scripts/TopArea.gd
@@ -14,6 +14,11 @@ var minimized_pos : Vector2
 var offset : Vector2 
 
 func _ready() -> void:
+	if ProjectSettings.get_setting("display/window/size/borderless") == false:
+		$Right/Maximize.hide()
+		$Right/Minimuze.hide()
+		$Right/Exit.hide()
+	
 	connect_signals()
 	var res = load(Defaults.TIMETRACKS_SAVE_PATH + Defaults.TIMETRACKS_SAVE_NAME)	# TODO: access this resource 
 		
@@ -32,7 +37,7 @@ func _on_mouse_exited() -> void:
 	set_process_input(false)
 
 func _input(event: InputEvent) -> void:
-	if event is InputEventMouseButton:
+	if event is InputEventMouseButton and ProjectSettings.get_setting("display/window/size/borderless") == true:
 		initial_mouse_pos = get_global_mouse_position()
 		if event.pressed:
 			offset = get_global_mouse_position()

--- a/Scripts/TopArea.gd
+++ b/Scripts/TopArea.gd
@@ -14,10 +14,11 @@ var minimized_pos : Vector2
 var offset : Vector2 
 
 func _ready() -> void:
-	if ProjectSettings.get_setting("display/window/size/borderless") == false:
+	if OS.get_borderless_window() == false:
 		$Right/Maximize.hide()
 		$Right/Minimuze.hide()
 		$Right/Exit.hide()
+		set_process_input(false)
 	
 	connect_signals()
 	var res = load(Defaults.TIMETRACKS_SAVE_PATH + Defaults.TIMETRACKS_SAVE_NAME)	# TODO: access this resource 
@@ -31,13 +32,14 @@ func connect_signals() -> void:
 		
 		
 func _on_mouse_entered() -> void:
-	set_process_input(true)
+	if OS.get_borderless_window() == true:
+		set_process_input(true)
 
 func _on_mouse_exited() -> void:
 	set_process_input(false)
 
 func _input(event: InputEvent) -> void:
-	if event is InputEventMouseButton and ProjectSettings.get_setting("display/window/size/borderless") == true:
+	if event is InputEventMouseButton:
 		initial_mouse_pos = get_global_mouse_position()
 		if event.pressed:
 			offset = get_global_mouse_position()

--- a/StartDialog.gd
+++ b/StartDialog.gd
@@ -1,0 +1,9 @@
+extends Control
+
+func _ready() -> void:
+	if OS.get_name() == "X11" or OS.get_name() == "Server":
+		ProjectSettings.set_setting("display/window/size/borderless", false)
+		get_tree().change_scene("res://Main.tscn")
+	else:
+		ProjectSettings.set_setting("display/window/size/borderless", true)
+		get_tree().change_scene("res://Main.tscn")

--- a/StartDialog.gd
+++ b/StartDialog.gd
@@ -2,8 +2,7 @@ extends Control
 
 func _ready() -> void:
 	if OS.get_name() == "X11" or OS.get_name() == "Server":
-		ProjectSettings.set_setting("display/window/size/borderless", false)
-		get_tree().change_scene("res://Main.tscn")
+		OS.set_borderless_window(false)
 	else:
-		ProjectSettings.set_setting("display/window/size/borderless", true)
-		get_tree().change_scene("res://Main.tscn")
+		OS.set_borderless_window(true)
+	get_tree().change_scene("res://Main.tscn")

--- a/StartDialog.tscn
+++ b/StartDialog.tscn
@@ -1,0 +1,8 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://StartDialog.gd" type="Script" id=1]
+
+[node name="Control" type="Control"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource( 1 )

--- a/project.godot
+++ b/project.godot
@@ -57,7 +57,7 @@ _global_script_class_icons={
 [application]
 
 config/name="MadProductivity"
-run/main_scene="res://Main.tscn"
+run/main_scene="res://StartDialog.tscn"
 run/low_processor_mode=true
 boot_splash/image="res://Splash.png"
 boot_splash/fullsize=false
@@ -75,7 +75,6 @@ Defaults="*res://Defaults.tscn"
 
 window/size/width=1100
 window/size/height=650
-window/size/borderless=true
 window/dpi/allow_hidpi=true
 window/per_pixel_transparency/allowed=true
 window/per_pixel_transparency/enabled=true


### PR DESCRIPTION
To fix issue #30, of custom controls not working on Fedora 34/KDE, I simply created a new scene that is ran when ever the project is launched. When it does this, it gets the operating system and if you are running an X11 or Server system, then it disables the custom controls, and enables the window manager default controls.