### PR TITLE
FIX: Issue #31

### DIFF
--- a/Assets/Views/TimeTrackingPanel.tscn
+++ b/Assets/Views/TimeTrackingPanel.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=20 format=2]
+[gd_scene load_steps=19 format=2]
 
 [ext_resource path="res://Assets/Themes/Dark/PanelSuperDarkGreen.tres" type="StyleBox" id=1]
 [ext_resource path="res://Scripts/Views/TimeTrackingPanel/TimeTrackingPanel.gd" type="Script" id=2]
@@ -7,7 +7,6 @@
 [ext_resource path="res://Assets/Textures/RoundProgress.png" type="Texture" id=5]
 [ext_resource path="res://Assets/Themes/Dark/PanelDarkGreen.tres" type="StyleBox" id=6]
 [ext_resource path="res://Assets/Themes/Dark/PanelGreenNoBorder.tres" type="StyleBox" id=7]
-[ext_resource path="res://Assets/Scenes/ChargeButton.tscn" type="PackedScene" id=8]
 [ext_resource path="res://Assets/Themes/Dark/PanelDarkGreenBorder.tres" type="StyleBox" id=9]
 [ext_resource path="res://Assets/Themes/Dark/LineEdit.tres" type="StyleBox" id=10]
 [ext_resource path="res://Assets/Themes/LineEditCool.tres" type="Theme" id=11]
@@ -160,85 +159,104 @@ __meta__ = {
 [node name="Control3" type="Control" parent="Content/VBoxContainer"]
 margin_top = 213.0
 margin_right = 199.0
-margin_bottom = 542.0
+margin_bottom = 338.0
 size_flags_vertical = 3
 
 [node name="PomodoroButtons" type="VBoxContainer" parent="Content/VBoxContainer"]
-visible = false
-margin_top = 410.0
+margin_top = 342.0
 margin_right = 199.0
-margin_bottom = 576.0
+margin_bottom = 542.0
 
-[node name="PomodoroStart" parent="Content/VBoxContainer/PomodoroButtons" instance=ExtResource( 8 )]
-margin_top = 0.0
+[node name="PomodoroStart" type="Button" parent="Content/VBoxContainer/PomodoroButtons"]
+margin_right = 199.0
 margin_bottom = 30.0
+rect_min_size = Vector2( 0, 30 )
+theme = ExtResource( 3 )
 text = "Start"
-instant = true
 
-[node name="PomodoroReset" parent="Content/VBoxContainer/PomodoroButtons" instance=ExtResource( 8 )]
-visible = false
-margin_top = 0.0
-margin_bottom = 30.0
+[node name="PomodoroReset" type="Button" parent="Content/VBoxContainer/PomodoroButtons"]
+margin_top = 34.0
+margin_right = 199.0
+margin_bottom = 64.0
+rect_min_size = Vector2( 0, 30 )
+theme = ExtResource( 3 )
 text = "Reset"
 
-[node name="PomodoroContinue" parent="Content/VBoxContainer/PomodoroButtons" instance=ExtResource( 8 )]
-visible = false
-margin_top = 34.0
-margin_bottom = 64.0
+[node name="PomodoroContinue" type="Button" parent="Content/VBoxContainer/PomodoroButtons"]
+margin_top = 68.0
+margin_right = 199.0
+margin_bottom = 98.0
+rect_min_size = Vector2( 0, 30 )
+theme = ExtResource( 3 )
 text = "Continue"
 
-[node name="PomodoroBreak" parent="Content/VBoxContainer/PomodoroButtons" instance=ExtResource( 8 )]
-visible = false
+[node name="PomodoroBreak" type="Button" parent="Content/VBoxContainer/PomodoroButtons"]
 margin_top = 102.0
+margin_right = 199.0
 margin_bottom = 132.0
+rect_min_size = Vector2( 0, 30 )
+theme = ExtResource( 3 )
 text = "Break"
 
-[node name="PomodoroFinish" parent="Content/VBoxContainer/PomodoroButtons" instance=ExtResource( 8 )]
-visible = false
-margin_top = 68.0
-margin_bottom = 98.0
+[node name="PomodoroFinish" type="Button" parent="Content/VBoxContainer/PomodoroButtons"]
+margin_top = 136.0
+margin_right = 199.0
+margin_bottom = 166.0
+rect_min_size = Vector2( 0, 30 )
+theme = ExtResource( 3 )
 text = "Finish"
 
-[node name="PomodoroCancel" parent="Content/VBoxContainer/PomodoroButtons" instance=ExtResource( 8 )]
-visible = false
-margin_top = 136.0
-margin_bottom = 166.0
+[node name="PomodoroCancel" type="Button" parent="Content/VBoxContainer/PomodoroButtons"]
+margin_top = 170.0
+margin_right = 199.0
+margin_bottom = 200.0
+rect_min_size = Vector2( 0, 30 )
+theme = ExtResource( 3 )
 text = "Cancel"
 
 [node name="NormalButtons" type="VBoxContainer" parent="Content/VBoxContainer"]
 visible = false
-margin_top = 546.0
+margin_top = 376.0
 margin_right = 199.0
-margin_bottom = 576.0
+margin_bottom = 542.0
 
-[node name="NormalStart" parent="Content/VBoxContainer/NormalButtons" instance=ExtResource( 8 )]
-margin_top = 0.0
+[node name="NormalStart" type="Button" parent="Content/VBoxContainer/NormalButtons"]
+margin_right = 199.0
 margin_bottom = 30.0
+rect_min_size = Vector2( 0, 30 )
+theme = ExtResource( 3 )
 text = "Start"
-instant = true
 
-[node name="NormalContinue" parent="Content/VBoxContainer/NormalButtons" instance=ExtResource( 8 )]
-visible = false
-margin_top = -102.0
-margin_bottom = -72.0
+[node name="NormalContinue" type="Button" parent="Content/VBoxContainer/NormalButtons"]
+margin_top = 34.0
+margin_right = 199.0
+margin_bottom = 64.0
+rect_min_size = Vector2( 0, 30 )
+theme = ExtResource( 3 )
 text = "Continue"
 
-[node name="NormalPause" parent="Content/VBoxContainer/NormalButtons" instance=ExtResource( 8 )]
-visible = false
-margin_top = 0.0
-margin_bottom = 30.0
+[node name="NormalPause" type="Button" parent="Content/VBoxContainer/NormalButtons"]
+margin_top = 68.0
+margin_right = 199.0
+margin_bottom = 98.0
+rect_min_size = Vector2( 0, 30 )
+theme = ExtResource( 3 )
 text = "Pause"
 
-[node name="NormalFinish" parent="Content/VBoxContainer/NormalButtons" instance=ExtResource( 8 )]
-visible = false
-margin_top = 0.0
-margin_bottom = 30.0
+[node name="NormalFinish" type="Button" parent="Content/VBoxContainer/NormalButtons"]
+margin_top = 102.0
+margin_right = 199.0
+margin_bottom = 132.0
+rect_min_size = Vector2( 0, 30 )
+theme = ExtResource( 3 )
 text = "Finish"
 
-[node name="NormalCancel" parent="Content/VBoxContainer/NormalButtons" instance=ExtResource( 8 )]
-visible = false
-margin_top = 0.0
-margin_bottom = 30.0
+[node name="NormalCancel" type="Button" parent="Content/VBoxContainer/NormalButtons"]
+margin_top = 136.0
+margin_right = 199.0
+margin_bottom = 166.0
+rect_min_size = Vector2( 0, 30 )
+theme = ExtResource( 3 )
 text = "Cancel"
 
 [node name="ItemInput" type="LineEdit" parent="Content/VBoxContainer"]

--- a/Scripts/Views/TimeTrackingPanel/TimeTrackingPanel.gd
+++ b/Scripts/Views/TimeTrackingPanel/TimeTrackingPanel.gd
@@ -118,6 +118,7 @@ func start_time_tracking() -> void:
 	notified = false
 	$Content/StateButtons/Normal.disabled = true
 	$Content/StateButtons/Pomodoro.disabled = true
+	$SecondsTimer.paused = false
 	$SecondsTimer.start()
 	
 	curr_track_item = TimeTrackItem.new()

--- a/Scripts/Views/TimeTrackingPanel/TimeTrackingPanel.gd
+++ b/Scripts/Views/TimeTrackingPanel/TimeTrackingPanel.gd
@@ -39,18 +39,18 @@ func _ready() -> void:
 	
 func hookup_signals() -> void:
 	# Pomodoro
-	$Content/VBoxContainer/PomodoroButtons/PomodoroStart.connect("charged",self, "on_pom_charged", [BUTTONS.START])
-	$Content/VBoxContainer/PomodoroButtons/PomodoroContinue.connect("charged",self, "on_pom_charged", [BUTTONS.CONTINUE])
-	$Content/VBoxContainer/PomodoroButtons/PomodoroFinish.connect("charged",self, "on_pom_charged", [BUTTONS.FINISH])
-	$Content/VBoxContainer/PomodoroButtons/PomodoroBreak.connect("charged",self, "on_pom_charged", [BUTTONS.BREAK])
-	$Content/VBoxContainer/PomodoroButtons/PomodoroCancel.connect("charged",self, "on_pom_charged", [BUTTONS.CANCEL])
-	$Content/VBoxContainer/PomodoroButtons/PomodoroReset.connect("charged",self, "on_pom_charged", [BUTTONS.RESET])
+	$Content/VBoxContainer/PomodoroButtons/PomodoroStart.connect("pressed",self, "on_pom_pressed", [BUTTONS.START])
+	$Content/VBoxContainer/PomodoroButtons/PomodoroContinue.connect("pressed",self, "on_pom_pressed", [BUTTONS.CONTINUE])
+	$Content/VBoxContainer/PomodoroButtons/PomodoroFinish.connect("pressed",self, "on_pom_pressed", [BUTTONS.FINISH])
+	$Content/VBoxContainer/PomodoroButtons/PomodoroBreak.connect("pressed",self, "on_pom_pressed", [BUTTONS.BREAK])
+	$Content/VBoxContainer/PomodoroButtons/PomodoroCancel.connect("pressed",self, "on_pom_pressed", [BUTTONS.CANCEL])
+	$Content/VBoxContainer/PomodoroButtons/PomodoroReset.connect("pressed",self, "on_pom_pressed", [BUTTONS.RESET])
 	# Normal
-	$Content/VBoxContainer/NormalButtons/NormalStart.connect("charged",self, "on_normal_charged", [BUTTONS.START])
-	$Content/VBoxContainer/NormalButtons/NormalPause.connect("charged",self, "on_normal_charged", [BUTTONS.PAUSE])
-	$Content/VBoxContainer/NormalButtons/NormalContinue.connect("charged",self, "on_normal_charged", [BUTTONS.CONTINUE])
-	$Content/VBoxContainer/NormalButtons/NormalFinish.connect("charged",self, "on_normal_charged", [BUTTONS.FINISH])
-	$Content/VBoxContainer/NormalButtons/NormalCancel.connect("charged",self, "on_normal_charged", [BUTTONS.CANCEL])
+	$Content/VBoxContainer/NormalButtons/NormalStart.connect("pressed",self, "on_normal_pressed", [BUTTONS.START])
+	$Content/VBoxContainer/NormalButtons/NormalPause.connect("pressed",self, "on_normal_pressed", [BUTTONS.PAUSE])
+	$Content/VBoxContainer/NormalButtons/NormalContinue.connect("pressed",self, "on_normal_pressed", [BUTTONS.CONTINUE])
+	$Content/VBoxContainer/NormalButtons/NormalFinish.connect("pressed",self, "on_normal_pressed", [BUTTONS.FINISH])
+	$Content/VBoxContainer/NormalButtons/NormalCancel.connect("pressed",self, "on_normal_pressed", [BUTTONS.CANCEL])
 	# others perhaps?
 
 
@@ -347,7 +347,7 @@ func _on_Pomodoro_pressed() -> void:
 	toggle_view(STATES.POMODORO)
 
 
-func on_pom_charged(which : int) -> void:
+func on_pom_pressed(which : int) -> void:
 	match which:
 		BUTTONS.BREAK:
 			start_pomodoro_break()
@@ -363,7 +363,7 @@ func on_pom_charged(which : int) -> void:
 			pomodoro_phase = 0
 			
 
-func on_normal_charged(which : int) -> void:
+func on_normal_pressed(which : int) -> void:
 	match which:
 		BUTTONS.PAUSE:
 			pause_time_tracking()


### PR DESCRIPTION
Fixed both issues described in #31 , changed the ChargeButtons to normal buttons instead, and changed their respective signal hookups and method names accordingly. Also added a line in TimeTrackingPanel.gd that avoids timer starting on paused.

Fixes mad-cookies-studio/mad-productivity#31